### PR TITLE
Enhance UI HTTP Interceptor to handle standardized API error codes

### DIFF
--- a/src/app/app-modules/core/services/http-interceptor.service.ts
+++ b/src/app/app-modules/core/services/http-interceptor.service.ts
@@ -34,7 +34,7 @@ export class HttpInterceptorService implements HttpInterceptor {
     readonly sessionstorage: SessionStorageService,
     public httpServiceService: HttpServiceService,
     private authService: AuthService,
-  ) {}
+  ) { }
 
   assignSelectedLanguage() {
     if (!this.currentLanguageSet) {
@@ -87,30 +87,46 @@ export class HttpInterceptorService implements HttpInterceptor {
       catchError((error: HttpErrorResponse) => {
         console.error(error);
         this.spinnerService.setLoading(false);
+
+        let errorMessage = 'Something went wrong. Please try again later.';
+        if (error.error && error.error.errorMessage) {
+          errorMessage = error.error.errorMessage;
+        } else if (error.message) {
+          errorMessage = error.message;
+        }
+
         if (error.status === 401) {
           this.handleSessionExpiry(
             this.currentLanguageSet.sessionExpiredPleaseLogin ||
-              'Session has expired, please login again.',
+            'Session has expired, please login again.',
           );
         } else if (error.status === 403) {
           this.handleSessionExpiry(
             this.currentLanguageSet.accessDenied ||
-              'Access Denied. You do not have permission to access this resource.',
+            'Access Denied. You do not have permission to access this resource.',
           );
+        } else if (error.status === 400) {
+          this.confirmationService.alert(errorMessage, 'error');
         } else if (error.status === 500) {
-          this.handleSessionExpiry(
-            this.currentLanguageSet.internaleServerError,
+          this.confirmationService.alert(
+            this.currentLanguageSet.internaleServerError || errorMessage,
+            'error'
           );
         } else {
-          this.handleSessionExpiry(
-            error.message ||
-              this.currentLanguageSet.somethingWentWrong ||
-              'Something went wrong. Please try again later.',
+          this.confirmationService.alert(
+            errorMessage ||
+            this.currentLanguageSet.somethingWentWrong,
+            'error'
           );
         }
-        sessionStorage.clear();
-        this.sessionstorage.clear();
-        return throwError(error.error);
+
+        // Only clear session on 401/403 or specific auth failures
+        if (error.status === 401 || error.status === 403) {
+          sessionStorage.clear();
+          this.sessionstorage.clear();
+        }
+
+        return throwError(error.error || error);
       }),
     );
   }
@@ -129,11 +145,11 @@ export class HttpInterceptorService implements HttpInterceptor {
     } else if (
       response.statusCode === 5000 &&
       response.errorMessage ===
-        'Unable to fetch session object from Redis server'
+      'Unable to fetch session object from Redis server'
     ) {
       this.handleSessionExpiry(
         this.currentLanguageSet.sessionExpiredPleaseLogin ||
-          'Session has expired, please login again.',
+        'Session has expired, please login again.',
       );
     } else {
       this.startTimer();
@@ -167,8 +183,8 @@ export class HttpInterceptorService implements HttpInterceptor {
             .subscribe((result: any) => {
               if (result.action === 'continue') {
                 this.http.post(environment.extendSessionUrl, {}).subscribe(
-                  (res: any) => {},
-                  (err: any) => {},
+                  (res: any) => { },
+                  (err: any) => { },
                 );
               } else if (result.action === 'timeout') {
                 clearTimeout(this.timerRef);
@@ -176,7 +192,7 @@ export class HttpInterceptorService implements HttpInterceptor {
                 this.sessionstorage.clear();
                 this.confirmationService.alert(
                   this.currentLanguageSet.sessionExpired ||
-                    'Session has expired, please login again.',
+                  'Session has expired, please login again.',
                   'error',
                 );
                 this.router.navigate(['/login']);
@@ -187,7 +203,7 @@ export class HttpInterceptorService implements HttpInterceptor {
                   this.sessionstorage.clear();
                   this.confirmationService.alert(
                     this.currentLanguageSet.sessionExpired ||
-                      'Session has expired, please login again.',
+                    'Session has expired, please login again.',
                     'error',
                   );
                   this.router.navigate(['/login']);


### PR DESCRIPTION
## Overview
This PR updates the frontend HTTP interceptor to align with the standardized error handling implemented in the HWC-API (Issue #115). It ensures that the UI correctly interprets RESTful status codes (4xx/5xx) and extracts user-friendly error messages from the backend's `OutputResponse` format.

## Changes
- **HttpInterceptorService**: Updated `intercept` logic to catch error responses.
- **Error Handling**: Implemented logic to parse the `OutputResponse` JSON from the error body and display the standardized error message to the user.
- **Status Code Support**: Added explicit handling for `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, and `500 Internal Server Error`.

## Testing
- Verified that the interceptor correctly catches 400 and 500 errors.
- Confirmed that the error message is correctly displayed in the UI notification/toast service.

## Related
This PR is a companion to the backend changes in the `HWC-API` repository under the same branch name: `fix/standardize-error-handling-115`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling with centralized resolution logic for API error responses.
  * Enhanced error alerts with consistent, status-specific messaging for HTTP 400, 500, and default error scenarios.
  * Refined session management to clear session data only when authentication errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->