### PR TITLE
Fix: Multiple Error Message Popups on Login Failure (HWC UI) #125

### DIFF
--- a/src/app/user-login/login/login.component.ts
+++ b/src/app/user-login/login/login.component.ts
@@ -264,7 +264,7 @@ export class LoginComponent implements OnInit {
                       this.resetCaptcha();
                       sessionStorage.clear();
                       this.router.navigate(['/login']);
-                      this.confirmationService.alert(res.errorMessage, 'error');
+  
                     }
                   });
               } else {
@@ -275,8 +275,12 @@ export class LoginComponent implements OnInit {
           },
           (err) => {
             this.resetCaptcha();
-            this.confirmationService.alert(err, 'error');
-          },
+            const errorMessage =
+    err?.error?.errorMessage ||
+    err?.message ||
+    'Login failed. Please check your credentials and try again.';
+  this.confirmationService.alert(errorMessage, 'error');
+},
         );
     }
   }


### PR DESCRIPTION
## Problem
Fixes #125

When login fails, two error popups were displayed:
1. One from the `else` block on session conflict cancel (with incorrect message)
2. One from the `err` callback with a raw error object (meaningless message)

## Changes Made
- Removed duplicate `confirmationService.alert()` from the session conflict cancel block
- Replaced raw `err` object in error callback with a meaningful fallback error message

## Expected Behaviour
- Single error popup shown on login failure
- Clear, meaningful error message displayed to the user


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error handling to display user-friendly messages when authentication fails, instead of showing technical error details
  * Refined error confirmation behavior during the authentication process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->