### PR TITLE
fix: Remove unmanaged subscription memory leak in AuthGuard

### DIFF
--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,34 +1,25 @@
 import { Injectable } from '@angular/core';
 import {
   CanActivate,
-  CanActivateChild,
   Router,
-  ActivatedRoute,
-  RouterStateSnapshot,
   ActivatedRouteSnapshot,
+  RouterStateSnapshot,
   UrlTree,
 } from '@angular/router';
 import { tap } from 'rxjs';
-import { HttpServiceService } from '../../core/services/http-service.service';
 import { AuthService } from './auth.service';
+
 @Injectable()
 export class AuthGuard implements CanActivate {
-  current_language_set: any;
   constructor(
     private auth: AuthService,
     private router: Router,
-    private route: ActivatedRoute,
-    private http_service: HttpServiceService,
   ) {}
 
   canActivate(route: any, state: any) {
-    this.http_service.currentLangugae$.subscribe(
-      (response) => (this.current_language_set = response),
-    );
     return this.auth.validateSessionKey().pipe(
       tap((res: any) => {
         if (!(res && res.statusCode === 200 && res.data)) {
-          const componentName = route.component ? route.component.name : '';
           this.router.navigate(['/login']);
         }
       }),


### PR DESCRIPTION
## Fix: Remove Memory Leak in AuthGuard

### Problem
The `AuthGuard.canActivate()` method created unmanaged subscriptions to `currentLangugae$` on every route activation, causing memory leaks because:
- Subscriptions never unsubscribed
- The assigned value (`current_language_set`) was never used
- AuthGuard is a singleton service, so subscriptions accumulated indefinitely
- Affected 7 protected routes: `/service`, `/servicePoint`, `/registrar`, `/nurse-doctor`, `/lab`, `/pharmacist`, `/datasync`

### Solution
✅ Removed the unused subscription entirely
✅ Removed unused `HttpServiceService` injection
✅ Cleaned up unused imports
✅ Simplified AuthGuard to focus only on session validation logic

### Changes
- Removed lines creating the memory leak subscription
- Removed unused constructor injection
- Cleaned up unused imports (`HttpServiceService`, `ActivatedRoute`, unused router imports)
- No change to authentication logic or behavior

### Impact
- Eliminates memory leak on every route activation
- Reduces constructor dependencies
- Cleaner, more maintainable code
- Zero behavioral changes

### Testing
- No changes to authentication flow
- Guard still validates session keys correctly
- Route protection intact

Fixes issue #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the authentication guard by removing language-state handling and related logic, leaving a streamlined session-key validation flow to reduce complexity and improve maintainability.

* **Chores**
  * Removed unused imports, constructor parameters and routing-related members to clean up code and reduce surface area for future changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->