### PR TITLE
fix(pharmacist): stop silent failure when redirecting to Inventory

### DIFF
--- a/src/app/app-modules/core/services/inventory.service.ts
+++ b/src/app/app-modules/core/services/inventory.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Inject } from '@angular/core';
 import { environment } from '../../../../environments/environment';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { HttpServiceService } from './http-service.service';
 @Injectable()
 export class InventoryService {
   inventoryUrl: any;
@@ -12,7 +13,12 @@ export class InventoryService {
     @Inject(DOCUMENT) private document: any,
     readonly sessionstorage: SessionStorageService,
     private confirmationService: ConfirmationService,
-  ) {}
+    private httpServiceService: HttpServiceService,
+  ) {
+    this.httpServiceService.currentLangugae$.subscribe(
+      (response) => (this.current_language_set = response),
+    );
+  }
 
   moveToInventory(
     benID: any,
@@ -80,6 +86,7 @@ export class InventoryService {
   getppID() {
     const serviceLineDetailsData: any =
       this.sessionstorage.getItem('serviceLineDetails');
+    if (!serviceLineDetailsData) return undefined;
     const serviceLineDetails = JSON.parse(serviceLineDetailsData);
     return serviceLineDetails.parkingPlaceID;
   }

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.ts
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.ts
@@ -318,7 +318,7 @@ export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
             beneficiary.visitCode,
             beneficiary.benFlowID,
             beneficiary.beneficiaryRegID,
-            sessionStorage.getItem('setLanguage') !== undefined
+            sessionStorage.getItem('setLanguage') !== null
               ? sessionStorage.getItem('setLanguage')
               : 'English',
             this.healthIDValue,


### PR DESCRIPTION
## Summary
- `InventoryService.current_language_set` was declared but never assigned. Whenever the redirect guard (`authKey && protocol && host && facility`) failed for any reason, the `else` branch tried to read `this.current_language_set.alerts.info.noFacilityMapper` and threw a `TypeError`, silently killing the whole flow before any alert or redirect happened — clicking the pharmacist worklist action looked like it did nothing.
- Fixed by populating `current_language_set` from `HttpServiceService.currentLangugae$`, the same pattern already used in `AuthGuard`.
- `getppID()` called `JSON.parse(serviceLineDetails).parkingPlaceID` with no null check — if `serviceLineDetails` wasn't in session storage, this threw before the redirect could fire. Added a guard.
- `worklist.component.ts` checked `sessionStorage.getItem('setLanguage') !== undefined`, which is always true since `getItem` returns `null`, not `undefined`, for a missing key — so the `'English'` fallback could never trigger. Fixed to check `!== null`.

## Test plan
- [ ] From the pharmacist worklist, trigger the dispense/redirect action and confirm the confirmation dialog appears and, on confirm, the app attempts navigation to the Inventory app instead of silently doing nothing
- [ ] Verify the "no facility mapped" alert now displays correctly (instead of throwing) when facility/auth session data is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)