### PR TITLE
fix(pharmacist): stop silent failure when redirecting to Inventory

### DIFF
--- a/src/app/app-modules/core/services/inventory.service.ts
+++ b/src/app/app-modules/core/services/inventory.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Inject } from '@angular/core';
 import { environment } from '../../../../environments/environment';
 import { ConfirmationService } from '../../core/services/confirmation.service';
 import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
+import { HttpServiceService } from './http-service.service';
 @Injectable()
 export class InventoryService {
   inventoryUrl: any;
@@ -12,7 +13,12 @@ export class InventoryService {
     @Inject(DOCUMENT) private document: any,
     readonly sessionstorage: SessionStorageService,
     private confirmationService: ConfirmationService,
-  ) {}
+    private httpServiceService: HttpServiceService,
+  ) {
+    this.httpServiceService.currentLangugae$.subscribe(
+      (response) => (this.current_language_set = response),
+    );
+  }
 
   moveToInventory(
     benID: any,
@@ -80,6 +86,7 @@ export class InventoryService {
   getppID() {
     const serviceLineDetailsData: any =
       this.sessionstorage.getItem('serviceLineDetails');
+    if (!serviceLineDetailsData) return undefined;
     const serviceLineDetails = JSON.parse(serviceLineDetailsData);
     return serviceLineDetails.parkingPlaceID;
   }

--- a/src/app/app-modules/pharmacist/worklist/worklist.component.ts
+++ b/src/app/app-modules/pharmacist/worklist/worklist.component.ts
@@ -318,7 +318,7 @@ export class WorklistComponent implements OnInit, OnDestroy, DoCheck {
             beneficiary.visitCode,
             beneficiary.benFlowID,
             beneficiary.beneficiaryRegID,
-            sessionStorage.getItem('setLanguage') !== undefined
+            sessionStorage.getItem('setLanguage') !== null
               ? sessionStorage.getItem('setLanguage')
               : 'English',
             this.healthIDValue,


### PR DESCRIPTION
InventoryService.current_language_set was declared but never assigned, so the guard's error-alert branch threw instead of showing a message whenever authKey/facility/host was missing — masking the real problem and making the redirect look like a no-op. Populate it from HttpServiceService.currentLangugae$, the same pattern AuthGuard already uses.

Also guard getppID() against a missing serviceLineDetails entry (JSON.parse(null).parkingPlaceID threw before the redirect could fire), and fix the setLanguage fallback check in worklist.component (sessionStorage.getItem returns null, never undefined).

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
