### PR TITLE
fix(doctor-worklist): guard against undefined success message in care-context popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AMRIT HWC-UI (Health and Wellness Centre UI) — an Angular 16 healthcare application for the PSMRI AMRIT platform. Supports nurse, doctor, lab technician, pharmacist, radiologist, and oncologist workflows including patient registration, vitals capture, clinical examination, diagnosis (ANC, PNC, NCD screening, immunization, family planning, CDSS), prescriptions, lab tests, drug dispensing, telemedicine specialist consultations, and offline data sync.
+
+## Build & Development Commands
+
+| Command | Purpose |
+|---------|---------|
+| `npm start` | Dev server on **port 4204** (`ng serve`) |
+| `npm run build-dev` | AOT dev build (increased heap) |
+| `npm run build-prod` | AOT production build (increased heap) |
+| `npm run build-ci` | CI build (generates `environment.ci.ts` from template + env vars) |
+| `npm test` | Run tests (Karma + Jasmine) |
+| `npm run lint` | ESLint |
+| `npm run lint:fix` | ESLint with auto-fix |
+| `npm run commit` | Commitizen conventional commit prompt |
+
+## Git Submodule: Common-UI
+
+`Common-UI/` is a git submodule from `https://github.com/PSMRI/Common-UI`. It provides:
+- `registrar` module (patient registration + `SessionStorageService`)
+- `feedback` module
+- `tracking` module (Matomo analytics)
+
+Initialize with:
+```bash
+git submodule update --init --recursive
+```
+
+Import paths use `Common-UI/src/...` (e.g., `Common-UI/src/registrar/registration.module`).
+
+## Architecture
+
+### Module Structure
+
+- **AppModule** — root module with hash-based routing (`useHash: true`)
+- **CoreModule** — singleton services, guards, shared components, directives, `MaterialModule`
+- **NurseDoctorModule** (lazy-loaded at `/nurse-doctor`) — primary clinical module:
+  - `visit-details` — visit type selection and details
+  - `vitals` — vitals capture
+  - `history` — medical/family/personal history
+  - `examination` — clinical examination
+  - `case-record` — diagnosis, prescriptions, investigations, referrals
+  - `case-sheet` — printable case sheet
+  - `screening` — NCD/IDRS screening
+  - `cdss` — Clinical Decision Support System
+  - `anc` / `pnc` — antenatal/postnatal care
+  - `immunization-service` — immunization workflows
+  - `family-planning` — family planning services
+  - `idrs` — IDRS screening tool
+  - `refer` — referral management
+  - `quick-consult` — quick consultation flow
+  - `scheduler` — embedded scheduling
+  - Role-specific worklists: `nurse-worklist-wrapper`, `doctor-worklist`, `doctor-tm-worklist-wrapper`, `doctor-tm-future-worklist`, `tc-specialist-worklist`, `tc-specialist-future-worklist`, `radiologist-worklist`, `oncologist-worklist`
+- **LabModule** (lazy-loaded at `/lab`) — lab test workflows
+- **PharmacistModule** (lazy-loaded at `/pharmacist`) — drug dispensing
+- **DataSYNCModule** (lazy-loaded at `/datasync`) — offline data synchronization
+- **RegistrationModule** (lazy-loaded at `/registrar`, from Common-UI) — patient registration
+- **FeedbackModule** (lazy-loaded at `/feedback`, from Common-UI) — feedback collection
+
+### Routing
+
+Root routes: `login`, `logout-tm`, `service`, `servicePoint`, `set-password`, `reset-password`, `set-security-questions`, plus lazy-loaded feature modules above.
+
+Nurse-doctor sub-routes include role-specific worklists and patient workarea.
+
+### State Management
+
+Angular services with `BehaviorSubject`/`Subject`. No NgRx. Encrypted sessionStorage via `ng-cryptostore`.
+
+### HTTP / Auth
+
+- HTTP interceptor attaches `Authorization`/`ServerAuthorization` headers, manages spinner, handles 27-minute session timeout with warning dialog, auto-logout on 401/5002
+- `AuthGuard` protects clinical routes
+- `CanDeactivateGuardService` prevents navigation with unsaved changes
+
+### Key Services
+
+- `ConfirmationService` — alert/confirm/remarks dialogs via `MatDialog`
+- `NurseService` / `DoctorService` — cross-component clinical state
+- `MasterdataService` — master data caching
+- `IotService` — Bluetooth device integration (localhost:8085)
+
+## Key Dependencies
+
+- Angular 16 + Angular Material 16
+- Bootstrap 5 (layout) + Font Awesome 4.7 (icons)
+- `crypto-js` — password encryption (AES + PBKDF2)
+- `ng-cryptostore` — encrypted sessionStorage
+- `moment` — date handling
+- `ng2-charts` + `chart.js` — charts
+- `ngx-webcam` — webcam capture
+- `recordrtc` — audio recording
+- `html2canvas` — screenshot/print
+- `ngx-bootstrap` — additional UI components
+- `ngx-pagination` — pagination
+- `file-saver` — file downloads
+- `jquery` — DOM manipulation (legacy)
+
+## Code Conventions
+
+- **License header**: All source files begin with the AMRIT GPL-3.0 license block
+- **Component prefix**: `app`
+- **Commit convention**: Conventional Commits enforced via commitlint + Husky
+- **Pre-commit hook**: `lint-staged` runs ESLint `--fix` on staged `.ts` files
+
+## Environment Configuration
+
+Environment files in `src/environments/`. CI build uses EJS template (`environment.ci.ts.template`) with env vars for API endpoints, encryption keys, captcha config, and tracking config.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Follow these naming patterns:
 
 Use conventional commits (enforced by Husky):
 
-```
+```text
 <type>(<scope>): <description>
 
 <body>
@@ -68,7 +68,7 @@ Use conventional commits (enforced by Husky):
 
 Example:
 
-```
+```text
 feat(auth): add login validation
 
 Added email and password validation on the login form.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to HWC-UI
+
+Thank you for contributing to the Health and Wellness Centre Angular project!
+
+## Prerequisites
+
+* **Node.js** v18.0.0 or higher
+* **Angular CLI** v16.0.0 or higher
+* **npm** v9.0.0 or higher
+
+## Local Setup
+
+1. **Clone the repository**
+
+```bash
+git clone https://github.com/PSMRI/HWC-UI.git
+cd HWC-UI
+git submodule update --init --recursive
+```
+
+2. **Install dependencies**
+
+```bash
+npm install
+```
+
+3. **Configure environment**
+
+```bash
+cp src/environments/environment.ts src/environments/environment.local.ts
+```
+
+Update `environment.local.ts` with your local API URLs:
+
+```typescript
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:8080'
+};
+```
+
+4. **Start the development server**
+
+```bash
+npm start
+```
+
+Navigate to `http://localhost:4200/`
+
+## Branch Naming Conventions
+
+Follow these naming patterns:
+
+* **Features**: `feat/feature-name`
+* **Bug Fixes**: `fix/bug-name`
+* **Chores**: `chore/task-name`
+* **Documentation**: `docs/doc-name`
+
+## Commit Message Format
+
+Use conventional commits (enforced by Husky):
+
+```text
+<type>(<scope>): <description>
+
+<body>
+```
+
+Example:
+
+```text
+feat(auth): add login validation
+
+Added email and password validation on the login form.
+```
+
+## Code Standards
+
+* No `console.log` statements in production code
+* Strict TypeScript mode required
+* Follow Angular style guide
+* ESLint compliance required
+
+## Testing
+
+```bash
+npm test
+npm run lint
+npm run lint:fix
+```
+
+## Pull Request Checklist
+
+* [ ] Branch follows naming conventions
+* [ ] Commits follow conventional format
+* [ ] `npm run lint` passes with no errors
+* [ ] `npm test` passes
+* [ ] No console statements in production code
+* [ ] PR description explains what changed and why
+
+## Questions?
+
+Refer to the [README.md](README.md) or open an issue in the [AMRIT repository](https://github.com/PSMRI/AMRIT/issues).
+
+---
+
+**Happy coding! 🚀**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to HWC-UI
+
+Thank you for contributing to the Health and Wellness Centre Angular project!
+
+## Prerequisites
+
+- **Node.js** v18.0.0 or higher
+- **Angular CLI** v16.0.0 or higher
+- **npm** v9.0.0 or higher
+
+## Local Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd HWC-UI
+   ```
+
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+3. **Start the development server**
+   ```bash
+   npm start
+   ```
+   Navigate to `http://localhost:4200/`
+
+## Branch Naming Conventions
+
+Follow these naming patterns:
+- **Features**: `feat/feature-name`
+- **Bug Fixes**: `fix/bug-name`
+- **Chores**: `chore/task-name`
+- **Documentation**: `docs/doc-name`
+
+Example: `feat/add-user-authentication`
+
+## Commit Message Format
+
+Use conventional commits:
+```
+<type>(<scope>): <subject>
+
+<body>
+```
+
+**Types**: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`
+
+Example:
+```
+feat(auth): add login validation
+
+Added email and password validation on the login form.
+```
+
+## Code Standards
+
+- **No console.log statements** in production code
+- **Strict TypeScript mode** required (`strict: true` in tsconfig.json)
+- Meaningful variable and function names
+- ESLint compliance
+- Follow Angular style guide
+
+## Testing
+
+Run tests before submitting PR:
+```bash
+npm test
+```
+
+## Pull Request Checklist
+
+- [ ] Branch follows naming conventions
+- [ ] Commits follow conventional format
+- [ ] Code passes linting: `npm run lint`
+- [ ] All tests pass: `npm test`
+- [ ] No console.log statements
+- [ ] TypeScript strict mode compliance
+- [ ] Updated documentation if applicable
+- [ ] PR has descriptive title and body
+
+## Questions?
+
+Refer to the [README.md](README.md) or create an issue for guidance.
+
+---
+
+**Happy coding!** 🚀

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,22 +11,36 @@ Thank you for contributing to the Health and Wellness Centre Angular project!
 ## Local Setup
 
 1. **Clone the repository**
-   ```bash
-   git clone <repository-url>
+```bash
+   git clone https://github.com/PSMRI/HWC-UI.git
    cd HWC-UI
-   ```
+   git submodule update --init --recursive
+```
 
 2. **Install dependencies**
    ```bash
    npm install
    ```
 
-3. **Start the development server**
-   ```bash
+3. **Configure environment**
+```bash
+   cp src/environments/environment.example.ts src/environments/environment.ts
+```
+   Update `environment.ts` with your local API URLs:
+```typescript
+   export const environment = {
+     production: false,
+     apiUrl: 'http://localhost:8080/api'
+   };
+```
+
+4. **Start the development server**
+```bash
    npm start
-   ```
+```
    Navigate to `http://localhost:4200/`
 
+   
 ## Branch Naming Conventions
 
 Follow these naming patterns:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,65 +4,70 @@ Thank you for contributing to the Health and Wellness Centre Angular project!
 
 ## Prerequisites
 
-- **Node.js** v18.0.0 or higher
-- **Angular CLI** v16.0.0 or higher
-- **npm** v9.0.0 or higher
+* **Node.js** v18.0.0 or higher
+* **Angular CLI** v16.0.0 or higher
+* **npm** v9.0.0 or higher
 
 ## Local Setup
 
 1. **Clone the repository**
+
 ```bash
-   git clone https://github.com/PSMRI/HWC-UI.git
-   cd HWC-UI
-   git submodule update --init --recursive
+git clone https://github.com/PSMRI/HWC-UI.git
+cd HWC-UI
+git submodule update --init --recursive
 ```
 
 2. **Install dependencies**
-   ```bash
-   npm install
-   ```
+
+```bash
+npm install
+```
 
 3. **Configure environment**
+
 ```bash
-   cp src/environments/environment.example.ts src/environments/environment.ts
+cp src/environments/environment.ts src/environments/environment.local.ts
 ```
-   Update `environment.ts` with your local API URLs:
+
+Update `environment.local.ts` with your local API URLs:
+
 ```typescript
-   export const environment = {
-     production: false,
-     apiUrl: 'http://localhost:8080/api'
-   };
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:8080'
+};
 ```
 
 4. **Start the development server**
-```bash
-   npm start
-```
-   Navigate to `http://localhost:4200/`
 
-   
+```bash
+npm start
+```
+
+Navigate to `http://localhost:4200/`
+
 ## Branch Naming Conventions
 
 Follow these naming patterns:
-- **Features**: `feat/feature-name`
-- **Bug Fixes**: `fix/bug-name`
-- **Chores**: `chore/task-name`
-- **Documentation**: `docs/doc-name`
 
-Example: `feat/add-user-authentication`
+* **Features**: `feat/feature-name`
+* **Bug Fixes**: `fix/bug-name`
+* **Chores**: `chore/task-name`
+* **Documentation**: `docs/doc-name`
 
 ## Commit Message Format
 
-Use conventional commits:
+Use conventional commits (enforced by Husky):
+
 ```
-<type>(<scope>): <subject>
+<type>(<scope>): <description>
 
 <body>
 ```
 
-**Types**: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`
-
 Example:
+
 ```
 feat(auth): add login validation
 
@@ -71,34 +76,32 @@ Added email and password validation on the login form.
 
 ## Code Standards
 
-- **No console.log statements** in production code
-- **Strict TypeScript mode** required (`strict: true` in tsconfig.json)
-- Meaningful variable and function names
-- ESLint compliance
-- Follow Angular style guide
+* No `console.log` statements in production code
+* Strict TypeScript mode required
+* Follow Angular style guide
+* ESLint compliance required
 
 ## Testing
 
-Run tests before submitting PR:
 ```bash
 npm test
+npm run lint
+npm run lint:fix
 ```
 
 ## Pull Request Checklist
 
-- [ ] Branch follows naming conventions
-- [ ] Commits follow conventional format
-- [ ] Code passes linting: `npm run lint`
-- [ ] All tests pass: `npm test`
-- [ ] No console.log statements
-- [ ] TypeScript strict mode compliance
-- [ ] Updated documentation if applicable
-- [ ] PR has descriptive title and body
+* [ ] Branch follows naming conventions
+* [ ] Commits follow conventional format
+* [ ] `npm run lint` passes with no errors
+* [ ] `npm test` passes
+* [ ] No console statements in production code
+* [ ] PR description explains what changed and why
 
 ## Questions?
 
-Refer to the [README.md](README.md) or create an issue for guidance.
+Refer to the [README.md](README.md) or open an issue in the [AMRIT repository](https://github.com/PSMRI/AMRIT/issues).
 
 ---
 
-**Happy coding!** 🚀
+**Happy coding! 🚀**

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "husky": "^9.1.7",
-        "jasmine-core": "~4.6.0",
+        "jasmine-core": "~5.12.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
         "karma-coverage": "~2.2.0",
@@ -2907,13 +2907,6 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/load/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/@commitlint/load/node_modules/chalk": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
@@ -2925,46 +2918,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@commitlint/message": {
@@ -5139,6 +5092,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@schematics/angular": {
@@ -7835,15 +7798,15 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "dependencies": {
+        "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
@@ -11378,9 +11341,9 @@
       }
     },
     "node_modules/jasmine-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.0.tgz",
-      "integrity": "sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.12.0.tgz",
+      "integrity": "sha512-QqO4pX33GEML5JoGQU6BM5NHKPgEsg+TXp3jCIDek9MbfEp2JUYEFBo9EF1+hegWy/bCHS1m5nP0BOp18G6rVA==",
       "dev": true
     },
     "node_modules/jest-worker": {
@@ -11678,6 +11641,12 @@
         "karma": "^6.0.0",
         "karma-jasmine": "^5.0.0"
       }
+    },
+    "node_modules/karma-jasmine/node_modules/jasmine-core": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
+      "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
+      "dev": true
     },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",
@@ -14933,6 +14902,50 @@
       "peerDependencies": {
         "postcss": "^7.0.0 || ^8.0.1",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/postcss-loader/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-loader/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -19422,7 +19435,8 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.18.6",
@@ -20422,38 +20436,11 @@
         "lodash.uniq": "^4.5.0"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
         "chalk": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
           "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
           "dev": true
-        },
-        "cosmiconfig": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-          "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-          "dev": true,
-          "requires": {
-            "env-paths": "^2.2.1",
-            "import-fresh": "^3.3.0",
-            "js-yaml": "^4.1.0",
-            "parse-json": "^5.2.0"
-          }
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         }
       }
     },
@@ -21778,7 +21765,8 @@
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.12.tgz",
       "integrity": "sha512-f9R9Qsk8v+ffDxryl6PQ7Wnf2JCNd4dDXOH+d/AuF06VFiwcwGDRDZpmqkAXbFxQfcWTbT1FFvfoJ+SFcJgXLA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -22082,6 +22070,12 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
       "dev": true
+    },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
     },
     "@schematics/angular": {
       "version": "16.2.10",
@@ -22642,7 +22636,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz",
       "integrity": "sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -22953,13 +22948,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -23388,7 +23385,8 @@
     "bootstrap": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
-      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g=="
+      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -24139,15 +24137,15 @@
       }
     },
     "cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "requires": {
+        "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "dependencies": {
         "argparse": {
@@ -24727,7 +24725,8 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
           "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -25097,7 +25096,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "5.1.3",
@@ -26213,7 +26213,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -26751,9 +26752,9 @@
       }
     },
     "jasmine-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.0.tgz",
-      "integrity": "sha512-O236+gd0ZXS8YAjFx8xKaJ94/erqUliEkJTDedyE7iHvv4ZVqi+q+8acJxu05/WJDKm512EUNn809In37nWlAQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.12.0.tgz",
+      "integrity": "sha512-QqO4pX33GEML5JoGQU6BM5NHKPgEsg+TXp3jCIDek9MbfEp2JUYEFBo9EF1+hegWy/bCHS1m5nP0BOp18G6rVA==",
       "dev": true
     },
     "jest-worker": {
@@ -27024,13 +27025,22 @@
       "dev": true,
       "requires": {
         "jasmine-core": "^4.1.0"
+      },
+      "dependencies": {
+        "jasmine-core": {
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
+          "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
+          "dev": true
+        }
       }
     },
     "karma-jasmine-html-reporter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.1.0.tgz",
       "integrity": "sha512-sPQE1+nlsn6Hwb5t+HHwyy0A1FNCVKuL1192b+XNauMYWThz2kweiBVW1DqloRpVvZIJkIoHVB7XRpK78n1xbQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -28324,7 +28334,8 @@
     "ng2-completer": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ng2-completer/-/ng2-completer-9.0.1.tgz",
-      "integrity": "sha512-zEKehHdCK8E/k4Y0HepprGdYBHr2AOsaq4QpeqoCyUElOOC5M3qi3ZEHV1VF54I7heBQktswwXe5UyWduJ0Xeg=="
+      "integrity": "sha512-zEKehHdCK8E/k4Y0HepprGdYBHr2AOsaq4QpeqoCyUElOOC5M3qi3ZEHV1VF54I7heBQktswwXe5UyWduJ0Xeg==",
+      "requires": {}
     },
     "ngx-bootstrap": {
       "version": "12.0.0",
@@ -29357,13 +29368,43 @@
         "cosmiconfig": "^8.2.0",
         "jiti": "^1.18.2",
         "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.2.0",
+            "path-type": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -30491,7 +30532,8 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
           "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -30923,7 +30965,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -31062,7 +31105,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "tsconfig-paths": {
       "version": "4.2.0",
@@ -31520,7 +31564,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -31609,7 +31654,8 @@
           "version": "8.16.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
           "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -31795,7 +31841,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "husky": "^9.1.7",
-    "jasmine-core": "~4.6.0",
+    "jasmine-core": "~5.12.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",

--- a/src/app/app-modules/core/services/auth-guard.service.ts
+++ b/src/app/app-modules/core/services/auth-guard.service.ts
@@ -1,34 +1,25 @@
 import { Injectable } from '@angular/core';
 import {
   CanActivate,
-  CanActivateChild,
   Router,
-  ActivatedRoute,
-  RouterStateSnapshot,
   ActivatedRouteSnapshot,
+  RouterStateSnapshot,
   UrlTree,
 } from '@angular/router';
 import { tap } from 'rxjs';
-import { HttpServiceService } from '../../core/services/http-service.service';
 import { AuthService } from './auth.service';
+
 @Injectable()
 export class AuthGuard implements CanActivate {
-  current_language_set: any;
   constructor(
     private auth: AuthService,
     private router: Router,
-    private route: ActivatedRoute,
-    private http_service: HttpServiceService,
   ) {}
 
   canActivate(route: any, state: any) {
-    this.http_service.currentLangugae$.subscribe(
-      (response) => (this.current_language_set = response),
-    );
     return this.auth.validateSessionKey().pipe(
       tap((res: any) => {
         if (!(res && res.statusCode === 200 && res.data)) {
-          const componentName = route.component ? route.component.name : '';
           this.router.navigate(['/login']);
         }
       }),

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/findings/findings.component.html
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/findings/findings.component.html
@@ -263,87 +263,84 @@
 
   <div class="row m-t-20">
     <ng-container formArrayName="clinicalObservationsList">
-      <div
+      <div class="row align-items-center m-t-10"
         *ngFor="
           let observations of getClinicalObservationsList();
           let i = index;
           let isLast = last
         "
       >
-        <ng-container [formGroupName]="i" class="col-12">
-          <div class="row">
-            <div class="col-8">
-              <mat-form-field class="input-full-width">
-                <mat-label>{{
-                  current_language_set?.casesheet?.clinicalObs
-                }}</mat-label>
-                <input
-                  matInput
-                  allowText="inputFieldValidator"
-                  appClinicalObservations
-                  [observationsList]="observations"
-                  name="viewObservationsProvided"
-                  formControlName="clinicalObservationsProvided"
-                  maxlength="100"
-                  minlength="3"
-                  [previousSelected]="
-                    generalFindingsForm.value.clinicalObservationsList
-                  "
-                  (focus)="trackFieldInteraction('Clinical Observations Input')"
-                />
-                <mat-icon
-                  class="search-btn cursorPointer"
-                  matSuffix
-                  appClinicalObservations
-                  [observationsList]="observations"
-                  [previousSelected]="
-                    generalFindingsForm.value.clinicalObservationsList
-                  "
-                  (click)="
-                    trackFieldInteraction('Search Clinical Observations')
-                  "
-                  >search</mat-icon
-                >
-              </mat-form-field>
-            </div>
+        <ng-container [formGroupName]="i">
+          <div class="col-xs-12 col-sm-8 col-md-9">
+            <mat-form-field class="input-full-width" appearance="fill">
+              <mat-label>{{
+                current_language_set?.casesheet?.clinicalObs
+              }}</mat-label>
+              <input
+                matInput
+                type="text"
+                autocomplete="off"
+                name="viewObservationsProvided"
+                formControlName="clinicalObservationsProvided"
+                minlength="3"
+                maxlength="100"
+                #observationInput
+                [matAutocomplete]="autoObservation"
+                (keyup)="onObservationInputKeyup(observationInput.value, i)"
+                (focus)="trackFieldInteraction('Clinical Observations Input')"
+              />
+            </mat-form-field>
 
-            <div class="col-4" style="margin-top: 10px">
-              <button
-                mat-mini-fab
-                type="button"
-                color="primary"
-                *ngIf="isLast"
-                [disabled]="validateAddedObservations(observations)"
-                (click)="
-                  addObservations();
-                  trackFieldInteraction('Add Clinical Observation')
-                "
-                class="mat-add-btn"
+            <mat-autocomplete
+              #autoObservation="matAutocomplete"
+              autoActiveFirstOption
+              [displayWith]="displayObservation"
+              (optionSelected)="onObservationSelected($event.option.value, i)"
+            >
+              <mat-option
+                *ngFor="let obs of suggestedObservationsList[i]"
+                [value]="obs"
               >
-                {{ current_language_set?.common?.add }}
-              </button>
+                {{ obs.term }}
+              </mat-option>
+            </mat-autocomplete>
+          </div>
 
-              <button
-                mat-mini-fab
-                type="button"
-                class="mat-remove-btn"
-                color="warn"
-                *ngIf="
-                  i !== 0 ||
-                  (i === 0 &&
-                    generalFindingsForm.get('clinicalObservationsList')?.value
-                      .clinicalObservationsProvided !== null &&
-                    generalFindingsForm.get('clinicalObservationsList')?.value
-                      .clinicalObservationsProvided !== '')
-                "
-                (click)="
-                  removeObservationsFromList(i, observations);
-                  trackFieldInteraction('Remove Clinical Observation')
-                "
-              >
-                {{ current_language_set?.common?.remove }}
-              </button>
-            </div>
+          <div class="col-xs-12 col-sm-4 col-md-3 d-flex align-items-center">
+            <button
+              mat-mini-fab
+              type="button"
+              color="primary"
+              *ngIf="isLast"
+              [disabled]="validateAddedObservations(observations)"
+              (click)="
+                addObservations();
+                trackFieldInteraction('Add Clinical Observation')
+              "
+              class="mat-add-btn m-r-10"
+            >
+              {{ current_language_set?.common?.add }}
+            </button>
+
+            <button
+              mat-mini-fab
+              type="button"
+              class="mat-remove-btn"
+              color="warn"
+              *ngIf="
+                observations.get('clinicalObservationsProvided')?.disabled ||
+                i !== 0 ||
+                (i === 0 &&
+                  generalFindingsForm.get('clinicalObservationsList')?.value[i]
+                    ?.clinicalObservationsProvided)
+              "
+              (click)="
+                removeObservationsFromList(i, observations);
+                trackFieldInteraction('Remove Clinical Observation')
+              "
+            >
+              {{ current_language_set?.common?.remove }}
+            </button>
           </div>
         </ng-container>
       </div>
@@ -351,92 +348,84 @@
   </div>
   <div class="row m-t-5">
     <ng-container formArrayName="significantFindingsList">
-      <div
+      <div class="row align-items-center m-t-10"
         *ngFor="
           let findings of getSignificantFindingsList();
           let i = index;
           let isLast = last
         "
       >
-        <ng-container [formGroupName]="i" class="col-12">
-          <div class="row">
-            <div class="col-8">
-              <mat-form-field class="input-full-width">
-                <mat-label>{{
-                  current_language_set?.casesheet?.significantFind
-                }}</mat-label>
-                <input
-                  matInput
-                  allowText="inputFieldValidator"
-                  appSignificantFindings
-                  [findingsList]="findings"
-                  name="viewFindingsProvided"
-                  formControlName="significantFindingsProvided"
-                  maxlength="100"
-                  minlength="3"
-                  [previousSelected]="
-                    generalFindingsForm.value.significantFindingsList
-                  "
-                  (keyup)="
-                    resetFindingsCheckbox(
-                      generalFindingsForm.get('significantFindingsList')?.value
-                        .significantFindingsProvided
-                    )
-                  "
-                  (focus)="trackFieldInteraction('Significant Findings Input')"
-                />
+        <ng-container [formGroupName]="i">
+          <div class="col-xs-12 col-sm-8 col-md-9">
+            <mat-form-field class="input-full-width" appearance="fill">
+              <mat-label>{{
+                current_language_set?.casesheet?.significantFind
+              }}</mat-label>
+              <input
+                matInput
+                type="text"
+                autocomplete="off"
+                name="viewFindingsProvided"
+                formControlName="significantFindingsProvided"
+                minlength="3"
+                maxlength="100"
+                #findingsInput
+                [matAutocomplete]="autoFindings"
+                (keyup)="onFindingsInputKeyup(findingsInput.value, i)"
+                (focus)="trackFieldInteraction('Significant Findings Input')"
+              />
+            </mat-form-field>
 
-                <mat-icon
-                  class="search-btn cursorPointer"
-                  matSuffix
-                  appSignificantFindings
-                  [findingsList]="findings"
-                  [previousSelected]="
-                    generalFindingsForm.value.significantFindingsList
-                  "
-                  (click)="trackFieldInteraction('Search Significant Findings')"
-                  >search</mat-icon
-                >
-              </mat-form-field>
-            </div>
-
-            <div class="col-4" style="margin-top: 10px">
-              <button
-                mat-mini-fab
-                type="button"
-                color="primary"
-                *ngIf="isLast"
-                [disabled]="validateAddedFindings(findings)"
-                (click)="
-                  addFindings();
-                  trackFieldInteraction('Add Significant Finding')
-                "
-                class="mat-add-btn"
+            <mat-autocomplete
+              #autoFindings="matAutocomplete"
+              autoActiveFirstOption
+              [displayWith]="displayFindings"
+              (optionSelected)="onFindingsSelected($event.option.value, i)"
+            >
+              <mat-option
+                *ngFor="let finding of suggestedFindingsSearchList[i]"
+                [value]="finding"
               >
-                {{ current_language_set?.common?.add }}
-              </button>
+                {{ finding.term }}
+              </mat-option>
+            </mat-autocomplete>
+          </div>
 
-              <button
-                mat-mini-fab
-                type="button"
-                color="warn"
-                class="mat-remove-btn"
-                *ngIf="
-                  i !== 0 ||
-                  (i === 0 &&
-                    generalFindingsForm.get('significantFindingsList')?.value
-                      .significantFindingsProvided !== null &&
-                    generalFindingsForm.get('significantFindingsList')?.value
-                      .significantFindingsProvided !== '')
-                "
-                (click)="
-                  removeFindingsFromList(i, findings);
-                  trackFieldInteraction('Remove Significant Finding')
-                "
-              >
-                {{ current_language_set?.common?.remove }}
-              </button>
-            </div>
+          <div class="col-xs-12 col-sm-4 col-md-3 d-flex align-items-center">
+            <button
+              mat-mini-fab
+              type="button"
+              color="primary"
+              *ngIf="isLast"
+              [disabled]="validateAddedFindings(findings)"
+              (click)="
+                addFindings();
+                trackFieldInteraction('Add Significant Finding')
+              "
+              class="mat-add-btn m-r-10"
+            >
+              {{ current_language_set?.common?.add }}
+            </button>
+
+            <button
+              mat-mini-fab
+              type="button"
+              color="warn"
+              class="mat-remove-btn"
+              *ngIf="
+                findings.get('significantFindingsProvided')?.disabled ||
+                i !== 0 ||
+                (i === 0 &&
+                  generalFindingsForm.get('significantFindingsList')?.value[i]
+                    ?.significantFindingsProvided)
+              "
+              (click)="
+                removeFindingsFromList(i, findings);
+                trackFieldInteraction('Remove Significant Finding')
+              "
+            >
+              {{ current_language_set?.common?.remove }}
+            </button>
           </div>
         </ng-container>
       </div>

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/findings/findings.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/findings/findings.component.ts
@@ -83,6 +83,11 @@ export class FindingsComponent implements OnInit, DoCheck, OnDestroy {
   current_language_set: any;
   enableIsHistory = false;
   enableProvisionalDiag = false;
+
+  suggestedObservationsList: any = [];
+  suggestedFindingsSearchList: any = [];
+  private latestObservationQuery: Map<number, string> = new Map();
+  private latestFindingsQuery: Map<number, string> = new Map();
   displayedColumns: any = [
     'chiefComplaintsDetails',
     'duration',
@@ -618,11 +623,7 @@ export class FindingsComponent implements OnInit, DoCheck, OnDestroy {
               findingsList.reset();
             }
             this.generalFindingsForm.markAsDirty();
-            this.resetFindingsCheckbox(
-              this.generalFindingsForm.controls[
-                'significantFindingsList'
-              ].value.at(0).term,
-            );
+            this.resetFindingsCheckbox();
           }
         });
     } else {
@@ -631,10 +632,7 @@ export class FindingsComponent implements OnInit, DoCheck, OnDestroy {
       } else {
         findingsList.reset();
       }
-      this.resetFindingsCheckbox(
-        this.generalFindingsForm.controls['significantFindingsList'].value.at(0)
-          .term,
-      );
+      this.resetFindingsCheckbox();
     }
   }
   patchCapturedClinicalObservations(clinicalObservations: any) {
@@ -686,12 +684,95 @@ export class FindingsComponent implements OnInit, DoCheck, OnDestroy {
         ].disable();
         if (findingsList.length < savedFindings.length) this.addFindings();
       }
-      this.resetFindingsCheckbox(
-        this.generalFindingsForm.controls['significantFindingsList'].value.at(0)
-          .term,
-      );
+      this.resetFindingsCheckbox();
     }
   }
+  // --- Clinical Observations: Autocomplete search ---
+  onObservationInputKeyup(value: string, index: number) {
+    const term = (value || '').trim();
+    this.latestObservationQuery.set(index, term);
+    const observationsFormArray = this.generalFindingsForm.get(
+      'clinicalObservationsList',
+    ) as FormArray;
+    const observationsFormGroup = observationsFormArray.at(index) as FormGroup;
+    observationsFormGroup.patchValue({ conceptID: null, term: null });
+    if (term.length >= 3) {
+      this.masterdataService.searchDiagnosisBasedOnPageNo(term, 0).subscribe({
+        next: (results: any) => {
+          if (this.latestObservationQuery.get(index) === term) {
+            this.suggestedObservationsList[index] =
+              results?.data?.sctMaster ?? [];
+          }
+        },
+        error: () => {
+          console.error('Error fetching observation data');
+        },
+      });
+    } else {
+      this.suggestedObservationsList[index] = [];
+    }
+  }
+
+  displayObservation(obs: any): string {
+    return typeof obs === 'string' ? obs : obs?.term || '';
+  }
+
+  onObservationSelected(selected: any, index: number) {
+    const observationsFormArray = this.generalFindingsForm.get(
+      'clinicalObservationsList',
+    ) as FormArray;
+    const observationsFormGroup = observationsFormArray.at(index) as FormGroup;
+    observationsFormGroup.patchValue({
+      clinicalObservationsProvided: selected?.term || null,
+      conceptID: selected?.conceptID || null,
+      term: selected?.term || null,
+    });
+  }
+
+  // --- Significant Findings: Autocomplete search ---
+  onFindingsInputKeyup(value: string, index: number) {
+    const term = (value || '').trim();
+    this.latestFindingsQuery.set(index, term);
+    const findingsFormArray = this.generalFindingsForm.get(
+      'significantFindingsList',
+    ) as FormArray;
+    const findingsFormGroup = findingsFormArray.at(index) as FormGroup;
+    findingsFormGroup.patchValue({ conceptID: null, term: null });
+    this.resetFindingsCheckbox();
+    if (term.length >= 3) {
+      this.masterdataService.searchDiagnosisBasedOnPageNo(term, 0).subscribe({
+        next: (results: any) => {
+          if (this.latestFindingsQuery.get(index) === term) {
+            this.suggestedFindingsSearchList[index] =
+              results?.data?.sctMaster ?? [];
+          }
+        },
+        error: () => {
+          console.error('Error fetching findings data');
+        },
+      });
+    } else {
+      this.suggestedFindingsSearchList[index] = [];
+    }
+  }
+
+  displayFindings(finding: any): string {
+    return typeof finding === 'string' ? finding : finding?.term || '';
+  }
+
+  onFindingsSelected(selected: any, index: number) {
+    const findingsFormArray = this.generalFindingsForm.get(
+      'significantFindingsList',
+    ) as FormArray;
+    const findingsFormGroup = findingsFormArray.at(index) as FormGroup;
+    findingsFormGroup.patchValue({
+      significantFindingsProvided: selected?.term || null,
+      conceptID: selected?.conceptID || null,
+      term: selected?.term || null,
+    });
+    this.resetFindingsCheckbox();
+  }
+
   ngOnDestroy() {
     if (this.doctorMasterDataSubscription)
       this.doctorMasterDataSubscription.unsubscribe();
@@ -702,26 +783,18 @@ export class FindingsComponent implements OnInit, DoCheck, OnDestroy {
     }
   }
 
-  resetFindingsCheckbox(significantFindingsProvidedValue: any) {
-    if (
-      this.generalFindingsForm.controls['significantFindingsList'].value
-        .length === 1 &&
-      (significantFindingsProvidedValue === undefined ||
-        significantFindingsProvidedValue === null ||
-        significantFindingsProvidedValue === '')
-    ) {
-      this.generalFindingsForm.controls['isForHistory'].patchValue(null);
-      this.enableIsHistory = false;
-    }
-
-    if (
-      this.generalFindingsForm.controls['significantFindingsList'].value
-        .length > 0 &&
-      significantFindingsProvidedValue !== null &&
-      significantFindingsProvidedValue !== ''
-    ) {
+  resetFindingsCheckbox() {
+    const findingsList = this.generalFindingsForm.get(
+      'significantFindingsList',
+    ) as FormArray;
+    const hasAnyFinding = findingsList.controls.some((ctrl) => {
+      const val = (ctrl as FormGroup).get('significantFindingsProvided')?.value;
+      return val !== null && val !== undefined && val !== '';
+    });
+    if (hasAnyFinding) {
       this.enableIsHistory = true;
     } else {
+      this.generalFindingsForm.controls['isForHistory'].patchValue(null);
       this.enableIsHistory = false;
     }
   }

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/prescription/prescription.component.html
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/prescription/prescription.component.html
@@ -70,7 +70,6 @@
             getFormValueChanged();
             trackFieldInteraction('Medicine Form Selection')
           "
-          required
         >
           <mat-option
             *ngFor="let item of drugFormMaster"
@@ -98,7 +97,6 @@
           (keyup)="filterMedicine(tempDrugName)"
           (blur)="reEnterMedicine()"
           (focus)="trackFieldInteraction('Medicine Name Input')"
-          required
           [matAutocomplete]="autoGroup"
         />
         <mat-autocomplete
@@ -129,7 +127,6 @@
           [(ngModel)]="currentPrescription.dose"
           [disabled]="!currentPrescription.drugID"
           (selectionChange)="trackFieldInteraction('Dosage Selection')"
-          required
         >
           <mat-option
             *ngFor="let item of filteredDrugDoseMaster"
@@ -152,7 +149,6 @@
           [(ngModel)]="currentPrescription.frequency"
           [disabled]="!currentPrescription.drugID"
           (selectionChange)="trackFieldInteraction('Frequency Selection')"
-          required
         >
           <mat-option
             *ngFor="let item of drugFrequencyMaster"
@@ -225,7 +221,6 @@
           [(ngModel)]="currentPrescription.qtyPrescribed"
           [disabled]="!currentPrescription.drugID"
           (selectionChange)="trackFieldInteraction('Quantity Selection')"
-          required
         >
           <mat-option
             *ngFor="let item of drugDurationMaster | slice: 0 : 5"

--- a/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.html
+++ b/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.html
@@ -725,7 +725,6 @@
                       name="form"
                       [(ngModel)]="tempform"
                       (selectionChange)="getFormValueChanged()"
-                      required
                     >
                       <mat-option
                         *ngFor="let item of drugFormMaster"
@@ -751,7 +750,6 @@
                       [(ngModel)]="tempDrugName"
                       (keyup)="filterMedicine(tempDrugName)"
                       (blur)="reEnterMedicine()"
-                      required
                       [matAutocomplete]="autoGroup"
                     />
                     <mat-autocomplete
@@ -784,7 +782,6 @@
                       name="dose"
                       [(ngModel)]="currentPrescription.dose"
                       [disabled]="!currentPrescription.drugID"
-                      required
                     >
                       <mat-option
                         *ngFor="let item of filteredDrugDoseMaster"
@@ -805,7 +802,6 @@
                       name="frequency"
                       [(ngModel)]="currentPrescription.frequency"
                       [disabled]="!currentPrescription.drugID"
-                      required
                     >
                       <mat-option
                         *ngFor="let item of drugFrequencyMaster"
@@ -829,7 +825,6 @@
                       name="duration"
                       [(ngModel)]="currentPrescription.duration"
                       [disabled]="!currentPrescription.drugID"
-                      required
                     >
                       <mat-option
                         *ngFor="let item of drugDurationMaster"
@@ -850,7 +845,6 @@
                       name="unit"
                       [(ngModel)]="currentPrescription.unit"
                       [disabled]="!currentPrescription.drugID"
-                      required
                     >
                       <mat-option
                         *ngFor="let item of drugDurationUnitMaster"
@@ -878,7 +872,6 @@
                       name="quantity"
                       [(ngModel)]="currentPrescription.qtyPrescribed"
                       [disabled]="!currentPrescription.drugID"
-                      required
                     >
                       <mat-option
                         *ngFor="let item of drugDurationMaster | slice: 0 : 5"

--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.html
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.html
@@ -13,6 +13,7 @@
         (keyup.enter)="preventSubmitOnEnter($event)"
       >
         <mat-horizontal-stepper
+          #stepper
           linear="false"
           (selectionChange)="updatePending($event)"
         >

--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
@@ -2930,32 +2930,6 @@ export class WorkareaComponent
         }
       }
     }
-    // Ensure doctor has added at least one prescription
-    if (this.attendant === 'doctor') {
-      try {
-        const drugPrescriptionForm = <FormGroup>(
-          (caseRecordForm && caseRecordForm.controls
-            ? caseRecordForm.controls['drugPrescriptionForm']
-            : null)
-        );
-        if (drugPrescriptionForm) {
-          let prescribedDrugs =
-            drugPrescriptionForm.value &&
-            drugPrescriptionForm.value.prescribedDrugs
-              ? drugPrescriptionForm.value.prescribedDrugs
-              : [];
-          prescribedDrugs = prescribedDrugs.filter((d: any) => !!d.createdBy);
-          if (!prescribedDrugs || prescribedDrugs.length === 0) {
-            required.push(
-              this.current_language_set?.Prescription?.prescriptionRequired ||
-                'Please add at least one prescription',
-            );
-          }
-        }
-      } catch (err) {
-        console.warn('Error validating prescription presence', err);
-      }
-    }
 
     if (required.length) {
       this.confirmationService.notify(

--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
@@ -3585,7 +3585,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -3724,31 +3725,6 @@ export class WorkareaComponent
         }
       }
     }
-    // For quick consult doctor flow, ensure at least one prescription exists
-    if (this.attendant === 'doctor') {
-      try {
-        const prescription =
-          form && form.controls ? form.controls['prescription'] : null;
-        if (prescription) {
-          let prescribedDrugs =
-            prescription.value && prescription.value.prescribedDrugs
-              ? prescription.value.prescribedDrugs
-              : [];
-          prescribedDrugs = prescribedDrugs.filter((d: any) => !!d.createdBy);
-          if (!prescribedDrugs || prescribedDrugs.length === 0) {
-            required.push(
-              this.current_language_set?.Prescription?.prescriptionRequired ||
-                'Please add at least one prescription',
-            );
-          }
-        }
-      } catch (err) {
-        console.warn(
-          'Error validating quick consult prescription presence',
-          err,
-        );
-      }
-    }
 
     if (required.length) {
       this.confirmationService.notify(
@@ -3846,13 +3822,15 @@ export class WorkareaComponent
                   labTestOrders.length > 0
                 ) {
                   this.confirmationService.alert(
-                    this.current_language_set.alerts.info.datafillSuccessfully,
+                    this.current_language_set?.alerts?.info
+                      ?.datafillSuccessfully ?? 'Data saved successfully',
                     'success',
                   );
                   this.navigateToSpecialistWorklist();
                 } else {
                   this.getHealthIDDetails(
-                    this.current_language_set.alerts.info.datafillSuccessfully,
+                    this.current_language_set?.alerts?.info
+                      ?.datafillSuccessfully ?? 'Data saved successfully',
                   );
                 }
               } else {
@@ -3864,13 +3842,15 @@ export class WorkareaComponent
                     this.schedulerData !== null)
                 ) {
                   this.confirmationService.alert(
-                    this.current_language_set.alerts.info.datafillSuccessfully,
+                    this.current_language_set?.alerts?.info
+                      ?.datafillSuccessfully ?? 'Data saved successfully',
                     'success',
                   );
                   this.navigateToDoctorWorklist();
                 } else {
                   this.getHealthIDDetails(
-                    this.current_language_set.alerts.info.datafillSuccessfully,
+                    this.current_language_set?.alerts?.info
+                      ?.datafillSuccessfully ?? 'Data saved successfully',
                   );
                 }
               }
@@ -4024,7 +4004,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -4100,7 +4081,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -4133,7 +4115,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -4169,7 +4152,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -4230,13 +4214,15 @@ export class WorkareaComponent
                     this.schedulerData !== null)
                 ) {
                   this.confirmationService.alert(
-                    this.current_language_set.alerts.info.datafillSuccessfully,
+                    this.current_language_set?.alerts?.info
+                      ?.datafillSuccessfully ?? 'Data saved successfully',
                     'success',
                   );
                   this.navigateToDoctorWorklist();
                 } else {
                   this.getHealthIDDetails(
-                    this.current_language_set.alerts.info.datafillSuccessfully,
+                    this.current_language_set?.alerts?.info
+                      ?.datafillSuccessfully ?? 'Data saved successfully',
                   );
                 }
               }
@@ -4310,7 +4296,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -4344,7 +4331,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -4387,13 +4375,15 @@ export class WorkareaComponent
       this.testsPrescribed.laboratoryList.length > 0
     ) {
       this.confirmationService.alert(
-        this.current_language_set.alerts.info.datafillSuccessfully,
+        this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+          'Data saved successfully',
         'success',
       );
       this.navigateToSpecialistWorklist();
     } else {
       this.getHealthIDDetails(
-        this.current_language_set.alerts.info.datafillSuccessfully,
+        this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+          'Data saved successfully',
       );
     }
   }
@@ -4411,13 +4401,15 @@ export class WorkareaComponent
       (this.schedulerData !== undefined && this.schedulerData !== null)
     ) {
       this.confirmationService.alert(
-        this.current_language_set.alerts.info.datafillSuccessfully,
+        this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+          'Data saved successfully',
         'success',
       );
       this.navigateToDoctorWorklist();
     } else {
       this.getHealthIDDetails(
-        this.current_language_set.alerts.info.datafillSuccessfully,
+        this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+          'Data saved successfully',
       );
     }
   }
@@ -5552,7 +5544,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -5585,7 +5578,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();
@@ -5615,7 +5609,8 @@ export class WorkareaComponent
           (res: any) => {
             if (res.statusCode === 200 && res.data !== null) {
               this.confirmationService.alert(
-                this.current_language_set.alerts.info.datafillSuccessfully,
+                this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+                  'Data saved successfully',
                 'success',
               );
               this.navigateToNurseWorklist();

--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
@@ -61,6 +61,7 @@ import { SetLanguageComponent } from '../../core/components/set-language.compone
 import { SpecialistLoginComponent } from '../../core/components/specialist-login/specialist-login.component';
 import { HttpServiceService } from '../../core/services/http-service.service';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatStepper } from '@angular/material/stepper';
 import { SessionStorageService } from 'Common-UI/src/registrar/services/session-storage.service';
 import { HealthIdDisplayModalComponent } from 'Common-UI/src/registrar/abha-components/health-id-display-modal/health-id-display-modal.component';
 import { RegistrarService } from 'Common-UI/src/registrar/services/registrar.service';
@@ -80,6 +81,9 @@ export class WorkareaComponent
 {
   @ViewChild('sidenav')
   sidenav: any;
+
+  @ViewChild('stepper')
+  stepper!: MatStepper;
 
   visitMode: any;
   ancMode: any;
@@ -521,9 +525,12 @@ export class WorkareaComponent
         cbacForm.controls['cbacFamilyHistoryBpdiabetes'].value === null ||
         cbacForm.controls['cbacFamilyHistoryBpdiabetes'].value === '')
     ) {
-      this.confirmationService.alert(
+      const dialogRef = this.confirmationService.alert(
         this.current_language_set.pleaseCompletePartCbac,
       );
+      dialogRef.afterClosed().subscribe(() => {
+        this.stepper.previous();
+      });
     }
   }
   checkMandatory() {
@@ -2374,7 +2381,7 @@ export class WorkareaComponent
       const diagForm3 = <FormGroup>diagForm2.controls[0];
       if (diagForm3.controls['viewProvisionalDiagnosisProvided'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
 
@@ -2387,8 +2394,7 @@ export class WorkareaComponent
               item.conceptID === '')
           )
             required.push(
-              this.current_language_set
-                .pleaseSelectprovisionalDiagnosisWithSnomedCode,
+              `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.pleaseSelectprovisionalDiagnosisWithSnomedCode}`,
             );
         });
       }
@@ -2498,7 +2504,7 @@ export class WorkareaComponent
 
       if (diagForm3.controls['viewProvisionalDiagnosisProvided'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
 
@@ -2511,8 +2517,7 @@ export class WorkareaComponent
               item.conceptID === '')
           )
             required.push(
-              this.current_language_set
-                .pleaseSelectprovisionalDiagnosisWithSnomedCode,
+              `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.pleaseSelectprovisionalDiagnosisWithSnomedCode}`,
             );
         });
       }
@@ -2536,8 +2541,7 @@ export class WorkareaComponent
               item.conceptID === '')
           )
             required.push(
-              this.current_language_set
-                .pleaseSelectprovisionalDiagnosisWithSnomedCode,
+              `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.pleaseSelectprovisionalDiagnosisWithSnomedCode}`,
             );
         });
       }
@@ -2553,7 +2557,7 @@ export class WorkareaComponent
       const diagForm3 = <FormGroup>diagForm2.controls[0];
       if (diagForm3.controls['viewProvisionalDiagnosisProvided'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
 
@@ -2566,8 +2570,7 @@ export class WorkareaComponent
               item.conceptID === '')
           )
             required.push(
-              this.current_language_set
-                .pleaseSelectprovisionalDiagnosisWithSnomedCode,
+              `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.pleaseSelectprovisionalDiagnosisWithSnomedCode}`,
             );
         });
       }
@@ -2582,7 +2585,7 @@ export class WorkareaComponent
       const diagForm1 = <FormGroup>diagForm.controls['diagnosisForm'];
       if (diagForm1.controls['provisionalDiagnosisPrimaryDoctor'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
     }
@@ -2596,7 +2599,7 @@ export class WorkareaComponent
       const diagForm1 = <FormGroup>diagForm.controls['diagnosisForm'];
       if (diagForm1.controls['provisionalDiagnosisPrimaryDoctor'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
     }
@@ -2913,7 +2916,9 @@ export class WorkareaComponent
           const temp =
             diagnosisForm1.controls['ncdScreeningConditionArray'].value;
           if (diagnosisForm1.controls['ncdScreeningConditionArray'].errors) {
-            required.push(this.current_language_set.casesheet.ncdCondition);
+            required.push(
+              `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.casesheet.ncdCondition}`,
+            );
           }
           let flag = false;
 
@@ -2926,7 +2931,9 @@ export class WorkareaComponent
             flag &&
             diagnosisForm1.controls['ncdScreeningConditionOther'].value === null
           )
-            required.push(this.current_language_set.nCDConditionOther);
+            required.push(
+              `${this.current_language_set?.common?.caseRecord ?? 'Case Record'}: ${this.current_language_set.nCDConditionOther}`,
+            );
         }
       }
     }
@@ -2937,9 +2944,52 @@ export class WorkareaComponent
         required,
       );
       this.resetSpinnerandEnableTheSubmitButton();
+      // Navigate back to the case record step if there are errors from that section,
+      // so the doctor can locate and fix the missing fields easily.
+      if (
+        (this.attendant === 'doctor' || this.designation === 'TC Specialist') &&
+        this.stepper
+      ) {
+        const hasCaseRecordErrors = required.some((msg: string) =>
+          msg
+            .toLowerCase()
+            .includes(
+              (
+                this.current_language_set?.common?.caseRecord ?? 'case record'
+              ).toLowerCase(),
+            ),
+        );
+        if (hasCaseRecordErrors) {
+          this.navigateToCaseRecordStep();
+        }
+      }
       return 0;
     } else {
       return 1;
+    }
+  }
+
+  navigateToCaseRecordStep(): void {
+    if (!this.stepper) return;
+    const steps = this.stepper.steps.toArray();
+    const idx = steps.findIndex((s: any) => {
+      const label = (s.label || '').toLowerCase();
+      return label.includes('case') || label.includes('record');
+    });
+    if (idx >= 0) {
+      this.stepper.selectedIndex = idx;
+    }
+  }
+
+  navigateToQuickConsultStep(): void {
+    if (!this.stepper) return;
+    const steps = this.stepper.steps.toArray();
+    const idx = steps.findIndex((s: any) => {
+      const label = (s.label || '').toLowerCase();
+      return label.includes('quick') || label.includes('consult');
+    });
+    if (idx >= 0) {
+      this.stepper.selectedIndex = idx;
     }
   }
   checkForSnomedCTCode(caseRecordForm: any) {
@@ -3624,7 +3674,9 @@ export class WorkareaComponent
       );
     }
     if (form.controls['clinicalObservation'].errors) {
-      required.push(this.current_language_set.casesheet.clinicalObs);
+      required.push(
+        `${this.current_language_set?.historyData?.QuickConsultDetails?.quickconsult ?? 'Quick Consult'}: ${this.current_language_set.casesheet.clinicalObs}`,
+      );
     }
     if (
       this.visitCategory === 'General OPD (QC)' &&
@@ -3641,7 +3693,7 @@ export class WorkareaComponent
       const diagForm3 = <FormGroup>diagForm2.controls[0];
       if (diagForm3.controls['viewProvisionalDiagnosisProvided'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.historyData?.QuickConsultDetails?.quickconsult ?? 'Quick Consult'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
 
@@ -3654,8 +3706,7 @@ export class WorkareaComponent
               item.conceptID === '')
           )
             required.push(
-              this.current_language_set
-                .pleaseSelectprovisionalDiagnosisWithSnomedCode,
+              `${this.current_language_set?.historyData?.QuickConsultDetails?.quickconsult ?? 'Quick Consult'}: ${this.current_language_set.pleaseSelectprovisionalDiagnosisWithSnomedCode}`,
             );
         });
       }
@@ -3673,7 +3724,7 @@ export class WorkareaComponent
       const diagForm3 = <FormGroup>diagForm2.controls[0];
       if (diagForm3.controls['viewProvisionalDiagnosisProvided'].errors) {
         required.push(
-          this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+          `${this.current_language_set?.historyData?.QuickConsultDetails?.quickconsult ?? 'Quick Consult'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
         );
       }
 
@@ -3686,8 +3737,7 @@ export class WorkareaComponent
               item.conceptID === '')
           )
             required.push(
-              this.current_language_set
-                .pleaseSelectprovisionalDiagnosisWithSnomedCode,
+              `${this.current_language_set?.historyData?.QuickConsultDetails?.quickconsult ?? 'Quick Consult'}: ${this.current_language_set.pleaseSelectprovisionalDiagnosisWithSnomedCode}`,
             );
         });
       }
@@ -3698,7 +3748,7 @@ export class WorkareaComponent
 
     if (form.controls['provisionalDiagnosisList'].errors) {
       required.push(
-        this.current_language_set.DiagnosisDetails.provisionaldiagnosis,
+        `${this.current_language_set?.historyData?.QuickConsultDetails?.quickconsult ?? 'Quick Consult'}: ${this.current_language_set.DiagnosisDetails.provisionaldiagnosis}`,
       );
     }
 
@@ -3732,6 +3782,9 @@ export class WorkareaComponent
         required,
       );
       this.resetSpinnerandEnableTheSubmitButton();
+      if (this.stepper) {
+        this.navigateToQuickConsultStep();
+      }
       return 0;
     } else {
       return 1;
@@ -4421,7 +4474,8 @@ export class WorkareaComponent
         'info',
         successResponseFromAPI +
           '. ' +
-          this.current_language_set.common.doYouWantToLinkCareContext,
+          (this.current_language_set?.common?.doYouWantToLinkCareContext ??
+            'Do you want to link care context?'),
       )
       .subscribe((res) => {
         if (res) {

--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
@@ -4469,10 +4469,14 @@ export class WorkareaComponent
   /* Fetch health ID detaiuls to link the visit */
   getHealthIDDetails(successResponseFromAPI: any) {
     this.getMappedAbdmFacility();
+    const successMessage =
+      successResponseFromAPI ??
+      this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+      'Data saved successfully';
     this.confirmationService
       .confirmCareContext(
         'info',
-        successResponseFromAPI +
+        successMessage +
           '. ' +
           (this.current_language_set?.common?.doYouWantToLinkCareContext ??
             'Do you want to link care context?'),

--- a/src/app/app-modules/registrar/registration/editRegistration.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/editRegistration.component.spec.ts
@@ -79,7 +79,7 @@ class RegistrarServiceMock {
       { maritalStatusID: 3, status: 'Divorced' },
       { maritalStatusID: 2, status: 'Married' },
       { maritalStatusID: 7, status: 'Not Applicable' },
-      { maritalStatusID: 4, status: 'Seperated' },
+      { maritalStatusID: 4, status: 'Separated' },
       { maritalStatusID: 1, status: 'Unmarried' },
       { maritalStatusID: 5, status: 'Widow' },
       { maritalStatusID: 6, status: 'Widower' },

--- a/src/app/app-modules/registrar/registration/editWrongRegistration.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/editWrongRegistration.component.spec.ts
@@ -63,7 +63,7 @@ class RegistrarServiceMock {
       { maritalStatusID: 3, status: 'Divorced' },
       { maritalStatusID: 2, status: 'Married' },
       { maritalStatusID: 7, status: 'Not Applicable' },
-      { maritalStatusID: 4, status: 'Seperated' },
+      { maritalStatusID: 4, status: 'Separated' },
       { maritalStatusID: 1, status: 'Unmarried' },
       { maritalStatusID: 5, status: 'Widow' },
       { maritalStatusID: 6, status: 'Widower' },

--- a/src/app/app-modules/registrar/registration/register-other-details/register-other-details.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/register-other-details/register-other-details.component.spec.ts
@@ -77,7 +77,7 @@ class RegistrarServiceMock {
       { maritalStatusID: 3, status: 'Divorced' },
       { maritalStatusID: 2, status: 'Married' },
       { maritalStatusID: 7, status: 'Not Applicable' },
-      { maritalStatusID: 4, status: 'Seperated' },
+      { maritalStatusID: 4, status: 'Separated' },
       { maritalStatusID: 1, status: 'Unmarried' },
       { maritalStatusID: 5, status: 'Widow' },
       { maritalStatusID: 6, status: 'Widower' },

--- a/src/app/app-modules/registrar/registration/register-personal-details/register-personal-details.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/register-personal-details/register-personal-details.component.spec.ts
@@ -77,7 +77,7 @@ class RegistrarServiceMock {
       { maritalStatusID: 3, status: 'Divorced' },
       { maritalStatusID: 2, status: 'Married' },
       { maritalStatusID: 7, status: 'Not Applicable' },
-      { maritalStatusID: 4, status: 'Seperated' },
+      { maritalStatusID: 4, status: 'Separated' },
       { maritalStatusID: 1, status: 'Unmarried' },
       { maritalStatusID: 5, status: 'Widow' },
       { maritalStatusID: 6, status: 'Widower' },

--- a/src/app/app-modules/registrar/registration/registration.component.spec.ts
+++ b/src/app/app-modules/registrar/registration/registration.component.spec.ts
@@ -77,7 +77,7 @@ class RegistrarServiceMock {
       { maritalStatusID: 3, status: 'Divorced' },
       { maritalStatusID: 2, status: 'Married' },
       { maritalStatusID: 7, status: 'Not Applicable' },
-      { maritalStatusID: 4, status: 'Seperated' },
+      { maritalStatusID: 4, status: 'Separated' },
       { maritalStatusID: 1, status: 'Unmarried' },
       { maritalStatusID: 5, status: 'Widow' },
       { maritalStatusID: 6, status: 'Widower' },

--- a/src/app/app-modules/registrar/search/search.component.spec.ts
+++ b/src/app/app-modules/registrar/search/search.component.spec.ts
@@ -93,7 +93,7 @@ class RegistrarServiceMock {
       { maritalStatusID: 3, status: 'Divorced' },
       { maritalStatusID: 2, status: 'Married' },
       { maritalStatusID: 7, status: 'Not Applicable' },
-      { maritalStatusID: 4, status: 'Seperated' },
+      { maritalStatusID: 4, status: 'Separated' },
       { maritalStatusID: 1, status: 'Unmarried' },
       { maritalStatusID: 5, status: 'Widow' },
       { maritalStatusID: 6, status: 'Widower' },

--- a/src/app/user-login/service-point/service-point.component.ts
+++ b/src/app/user-login/service-point/service-point.component.ts
@@ -85,11 +85,10 @@ export class ServicePointComponent implements OnInit, DoCheck {
 
   ngOnInit() {
     this.assignSelectedLanguage();
-    this.serviceProviderId !== this.sessionstorage.getItem('providerServiceID');
-    this.userId !== this.sessionstorage.getItem('userID');
+    this.serviceProviderId = this.sessionstorage.getItem('providerServiceID');
+    this.userId = this.sessionstorage.getItem('userID');
     this.getServicePoint();
     this.getCdssAdminStatus();
-    console.log('here at three', this.current_language_set);
   }
 
   ngDoCheck() {
@@ -144,7 +143,6 @@ export class ServicePointComponent implements OnInit, DoCheck {
   }
 
   filterVanList(vanServicepointDetails: any) {
-    console.log('vanServicepointDetails', vanServicepointDetails);
     this.vansList = vanServicepointDetails.filter((van: any) => {
       if (van.vanSession === 3) {
         return van;
@@ -180,7 +178,6 @@ export class ServicePointComponent implements OnInit, DoCheck {
   }
 
   routeToDesignation(designation: any) {
-    console.log('designation', designation);
     switch (designation) {
       case 'Registrar':
         this.router.navigate(['/registrar/registration']);
@@ -214,7 +211,7 @@ export class ServicePointComponent implements OnInit, DoCheck {
         if (res && res.statusCode === 200) {
           this.saveDemographicsToStorage(res.data);
         } else {
-          this.locationGathetingIssues();
+          this.locationGatheringIssues();
         }
       });
   }
@@ -225,12 +222,13 @@ export class ServicePointComponent implements OnInit, DoCheck {
         this.sessionstorage.setItem('location', JSON.stringify(data));
         this.goToWorkList();
       } else {
-        this.locationGathetingIssues();
+        this.locationGatheringIssues();
+        return;
       }
     } else {
-      this.locationGathetingIssues();
+      this.locationGatheringIssues();
+      return;
     }
-    console.log('statesList', this.statesList);
     this.stateID = data.stateMaster.stateID;
   }
 
@@ -239,7 +237,6 @@ export class ServicePointComponent implements OnInit, DoCheck {
   }
 
   fetchDistrictsOnStateSelection(stateID: any) {
-    console.log('stateID', stateID); // Add this log statement
     this.registrarService
       .getDistrictList(this.stateID)
       .subscribe((res: any) => {
@@ -314,7 +311,7 @@ export class ServicePointComponent implements OnInit, DoCheck {
     this.routeToDesignation(this.designation);
   }
 
-  locationGathetingIssues() {
+  locationGatheringIssues() {
     const getLanguageJson = new SetLanguageComponent(this.httpServiceService);
     getLanguageJson.setLanguage();
     this.current_language_set = getLanguageJson.currentLanguageObject;

--- a/src/app/user-login/service-point/service-point.component.ts
+++ b/src/app/user-login/service-point/service-point.component.ts
@@ -85,11 +85,10 @@ export class ServicePointComponent implements OnInit, DoCheck {
 
   ngOnInit() {
     this.assignSelectedLanguage();
-    this.serviceProviderId !== this.sessionstorage.getItem('providerServiceID');
-    this.userId !== this.sessionstorage.getItem('userID');
+    this.serviceProviderId = this.sessionstorage.getItem('providerServiceID');
+    this.userId = this.sessionstorage.getItem('userID');
     this.getServicePoint();
     this.getCdssAdminStatus();
-    console.log('here at three', this.current_language_set);
   }
 
   ngDoCheck() {
@@ -144,7 +143,6 @@ export class ServicePointComponent implements OnInit, DoCheck {
   }
 
   filterVanList(vanServicepointDetails: any) {
-    console.log('vanServicepointDetails', vanServicepointDetails);
     this.vansList = vanServicepointDetails.filter((van: any) => {
       if (van.vanSession === 3) {
         return van;
@@ -180,7 +178,6 @@ export class ServicePointComponent implements OnInit, DoCheck {
   }
 
   routeToDesignation(designation: any) {
-    console.log('designation', designation);
     switch (designation) {
       case 'Registrar':
         this.router.navigate(['/registrar/registration']);
@@ -214,7 +211,7 @@ export class ServicePointComponent implements OnInit, DoCheck {
         if (res && res.statusCode === 200) {
           this.saveDemographicsToStorage(res.data);
         } else {
-          this.locationGathetingIssues();
+          this.locationGatheringIssues();
         }
       });
   }
@@ -225,12 +222,11 @@ export class ServicePointComponent implements OnInit, DoCheck {
         this.sessionstorage.setItem('location', JSON.stringify(data));
         this.goToWorkList();
       } else {
-        this.locationGathetingIssues();
+        this.locationGatheringIssues();
       }
     } else {
-      this.locationGathetingIssues();
+      this.locationGatheringIssues();
     }
-    console.log('statesList', this.statesList);
     this.stateID = data.stateMaster.stateID;
   }
 
@@ -239,7 +235,6 @@ export class ServicePointComponent implements OnInit, DoCheck {
   }
 
   fetchDistrictsOnStateSelection(stateID: any) {
-    console.log('stateID', stateID); // Add this log statement
     this.registrarService
       .getDistrictList(this.stateID)
       .subscribe((res: any) => {
@@ -314,7 +309,7 @@ export class ServicePointComponent implements OnInit, DoCheck {
     this.routeToDesignation(this.designation);
   }
 
-  locationGathetingIssues() {
+  locationGatheringIssues() {
     const getLanguageJson = new SetLanguageComponent(this.httpServiceService);
     getLanguageJson.setLanguage();
     this.current_language_set = getLanguageJson.currentLanguageObject;

--- a/src/app/user-login/service-point/service-point.component.ts
+++ b/src/app/user-login/service-point/service-point.component.ts
@@ -223,9 +223,11 @@ export class ServicePointComponent implements OnInit, DoCheck {
         this.goToWorkList();
       } else {
         this.locationGatheringIssues();
+        return;
       }
     } else {
       this.locationGatheringIssues();
+      return;
     }
     this.stateID = data.stateMaster.stateID;
   }

--- a/src/app/user-login/service/service.component.ts
+++ b/src/app/user-login/service/service.component.ts
@@ -374,7 +374,7 @@ export class ServiceComponent implements OnInit, DoCheck {
         if (res && res.statusCode === 200) {
           this.saveDemographicsToStorage(res.data);
         } else {
-          this.locationGathetingIssues();
+          this.locationGatheringIssues();
         }
       });
   }
@@ -384,18 +384,17 @@ export class ServiceComponent implements OnInit, DoCheck {
       if (data.stateMaster && data.stateMaster.length >= 1) {
         this.sessionstorage.setItem('location', JSON.stringify(data));
       } else {
-        this.locationGathetingIssues();
+        this.locationGatheringIssues();
       }
     } else {
-      this.locationGathetingIssues();
+      this.locationGatheringIssues();
     }
 
-    console.log('statesList', this.statesList);
     this.stateID = data.stateMaster.stateID;
     this.saveLocationDataToStorage();
   }
 
-  locationGathetingIssues() {
+  locationGatheringIssues() {
     const getLanguageJson = new SetLanguageComponent(this.httpServiceService);
     getLanguageJson.setLanguage();
     this.current_language_set = getLanguageJson.currentLanguageObject;

--- a/src/app/user-login/service/service.component.ts
+++ b/src/app/user-login/service/service.component.ts
@@ -374,7 +374,7 @@ export class ServiceComponent implements OnInit, DoCheck {
         if (res && res.statusCode === 200) {
           this.saveDemographicsToStorage(res.data);
         } else {
-          this.locationGathetingIssues();
+          this.locationGatheringIssues();
         }
       });
   }
@@ -384,18 +384,19 @@ export class ServiceComponent implements OnInit, DoCheck {
       if (data.stateMaster && data.stateMaster.length >= 1) {
         this.sessionstorage.setItem('location', JSON.stringify(data));
       } else {
-        this.locationGathetingIssues();
+        this.locationGatheringIssues();
+        return;
       }
     } else {
-      this.locationGathetingIssues();
+      this.locationGatheringIssues();
+      return;
     }
 
-    console.log('statesList', this.statesList);
     this.stateID = data.stateMaster.stateID;
     this.saveLocationDataToStorage();
   }
 
-  locationGathetingIssues() {
+  locationGatheringIssues() {
     const getLanguageJson = new SetLanguageComponent(this.httpServiceService);
     getLanguageJson.setLanguage();
     this.current_language_set = getLanguageJson.currentLanguageObject;

--- a/src/app/user-login/service/service.component.ts
+++ b/src/app/user-login/service/service.component.ts
@@ -385,9 +385,11 @@ export class ServiceComponent implements OnInit, DoCheck {
         this.sessionstorage.setItem('location', JSON.stringify(data));
       } else {
         this.locationGatheringIssues();
+        return;
       }
     } else {
       this.locationGatheringIssues();
+      return;
     }
 
     this.stateID = data.stateMaster.stateID;


### PR DESCRIPTION
## Summary
- When a beneficiary returns from the lab and the doctor clicks **Update** on the doctor worklist, the success dialog literally showed the text "undefined" instead of a proper success message.
- Root cause: `getHealthIDDetails()` in `workarea.component.ts` builds the popup text via `successResponseFromAPI + '. ' + ...`. The Update flow passes `res.data.response` into this function with no fallback (unlike the initial Save flow, which always supplies a hardcoded fallback string). Whenever that API field was falsy, `undefined + '. '` coerced to the literal string `"undefined. "` in the dialog.
- Fix: guard the message with a nullish-coalescing fallback (reusing the same `datafillSuccessfully` translation key the Save flow already relies on), so the popup always shows a real success message regardless of the response shape.

## Test plan
- [ ] As a doctor, complete a General OPD consultation and prescribe a lab test so the beneficiary routes to the lab.
- [ ] Complete the lab test as lab technician.
- [ ] Reopen the beneficiary from the doctor worklist and click **Update** without prescribing further tests/scheduling.
- [ ] Confirm the care-context popup shows a proper success message (not "undefined").
- [ ] Repeat for at least one other visit category that shares this code path (e.g. ANC/PNC/NCD) to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved care-context confirmation messaging when the health ID API returns no success message.
  * Displays the localized “Data saved successfully” message, with a default fallback if localization is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->