### PR TITLE
fix(doctor-worklist): guard against undefined success message in care-context popup

### DIFF
--- a/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
+++ b/src/app/app-modules/nurse-doctor/workarea/workarea.component.ts
@@ -4469,10 +4469,14 @@ export class WorkareaComponent
   /* Fetch health ID detaiuls to link the visit */
   getHealthIDDetails(successResponseFromAPI: any) {
     this.getMappedAbdmFacility();
+    const successMessage =
+      successResponseFromAPI ??
+      this.current_language_set?.alerts?.info?.datafillSuccessfully ??
+      'Data saved successfully';
     this.confirmationService
       .confirmCareContext(
         'info',
-        successResponseFromAPI +
+        successMessage +
           '. ' +
           (this.current_language_set?.common?.doYouWantToLinkCareContext ??
             'Do you want to link care context?'),


### PR DESCRIPTION
Rebased replacement for #284, which was cut from `main` and therefore carried 17 unrelated commits (CLAUDE.md, CONTRIBUTING.md, auth-guard fix, jasmine bump, `environment.*.ts` edits) into the `vb/hwc-3.8.1` release line and could not merge. This branch is a clean descendant of `vb/hwc-3.8.1` with only the fix.

## Problem

After a beneficiary returns from the lab and the doctor clicks Update on the doctor worklist, `getHealthIDDetails()` concatenated `res.data.response` straight into the care-context popup text. When that field was null/undefined, `undefined + '. '` rendered the literal word **"undefined"** in the success dialog.

## Fix

Fall back to `alerts.info.datafillSuccessfully` (then a plain English default), matching the pattern the initial Save flow already uses a few lines above. The guard sits inside `getHealthIDDetails()`, so all 16 call sites that pass `res.data.response` raw are covered by the single change.

## Verification

- Prettier: clean
- ESLint: clean
- Commit subject 83 chars, within commitlint's 100-char limit
- Diff is 1 file, +5 −1; fast-forwardable onto `vb/hwc-3.8.1` with no conflict

Supersedes #284 — that PR can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)